### PR TITLE
isaac_ros_data_validation: remove stray quotes from the license tag

### DIFF
--- a/isaac_ros_data_validation/package.xml
+++ b/isaac_ros_data_validation/package.xml
@@ -5,7 +5,7 @@
   <version>3.2.5</version>
   <description>"Validation tools for Isaac ROS Nova"</description>
   <maintainer email="isaac-ros-maintainers@nvidia.com">Isaac ROS Maintainers</maintainer>
-  <license>"NVIDIA Isaac ROS Software License"</license>
+  <license>NVIDIA Isaac ROS Software License</license>
   <build_depend>isaac_ros_common</build_depend>
 
   <depend>isaac_ros_nova_interfaces</depend>


### PR DESCRIPTION
The <license> element contains a quoted string:

    <license>"NVIDIA Isaac ROS Software License"</license>

Every other package in the release that uses this license writes it unquoted, so the quotes break exact-match license tooling for no benefit. This only changes the formatting, not the license.

Found while building an SPDX-style license inventory of Isaac ROS 4.5.0.